### PR TITLE
Updates

### DIFF
--- a/anchor/src/lib.rs
+++ b/anchor/src/lib.rs
@@ -29,7 +29,8 @@ pub mod prelude {
     };
 
     pub use otter_solana_macro::{
-        access_control, account, declare_id, error_code, invariant, program, Accounts, InitSpace,
+        access_control, account, declare_id, error_code, helper_fn, invariant, program, Accounts,
+        InitSpace,
     };
 
     pub use crate::account::{self, Account};

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -57,6 +57,13 @@ pub fn access_control(_args: TokenStream, item: TokenStream) -> TokenStream {
         .into()
 }
 
+#[proc_macro_attribute]
+pub fn helper_fn(_args: TokenStream, item: TokenStream) -> TokenStream {
+    core::access_control::access_control(item.into())
+        .expect("helper_fn used on non-function?")
+        .into()
+}
+
 #[cfg(feature = "verify")]
 #[proc_macro_attribute]
 pub fn verify(args: TokenStream, item: TokenStream) -> TokenStream {

--- a/macro_core/src/access_control.rs
+++ b/macro_core/src/access_control.rs
@@ -7,7 +7,7 @@ use crate::program::remove_verify_ignore_statements;
 #[cfg(feature = "anchor")]
 pub fn access_control(input: TokenStream) -> Result<TokenStream> {
     let Ok(mut item) = syn::parse2::<ItemFn>(input) else {
-        panic!("use #[verify] on a function")
+        panic!("use #[access_control] on a function")
     };
     remove_verify_ignore_statements(&mut item);
 

--- a/macro_core/src/error.rs
+++ b/macro_core/src/error.rs
@@ -17,6 +17,12 @@ pub fn error_code(_args: TokenStream, item: TokenStream) -> Result<TokenStream> 
                 <Self as std::fmt::Debug>::fmt(self, f)
             }
         }
+
+        impl From<#ident> for anchor_lang::prelude::Error {
+            fn from(value: #ident) -> Self {
+                anchor_lang::prelude::Error::CustomError(value.to_string())
+            }
+        }
     };
     Ok(res)
 }

--- a/macro_core/src/helper.rs
+++ b/macro_core/src/helper.rs
@@ -1,0 +1,17 @@
+#[cfg(feature = "anchor")]
+use {anyhow::Result, proc_macro2::TokenStream, quote::quote, syn::ItemFn};
+
+#[cfg(feature = "anchor")]
+use crate::program::remove_verify_ignore_statements;
+
+#[cfg(feature = "anchor")]
+pub fn access_control(input: TokenStream) -> Result<TokenStream> {
+    let Ok(mut item) = syn::parse2::<ItemFn>(input) else {
+        panic!("use #[helper] on a function")
+    };
+    remove_verify_ignore_statements(&mut item);
+
+    Ok(quote! {
+        #item
+    })
+}

--- a/program/src/account_info.rs
+++ b/program/src/account_info.rs
@@ -47,7 +47,7 @@ impl<'a> AccountInfo<'a> {
     }
 
     pub fn realloc(&self, _new_len: usize, _zero_init: bool) -> Result<()> {
-        todo!()
+        Ok(())
     }
 
     pub fn data_len(&self) -> usize {

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -194,4 +194,8 @@ pub enum Error {
 
     #[error("generic error")]
     Generic,
+
+    // Custom errors for the program specific errors.
+    #[error("An error occurred: {0}")]
+    CustomError(String),
 }


### PR DESCRIPTION
- Added `helper_fn` macro to expose verify_ignore for some functions which were used by instructions.
- Added Implementation `From<ERROR> for anchor_lang::prelude::Error`